### PR TITLE
invalid await invocation removed in chooseBranch

### DIFF
--- a/src/PioneerUtils.jsm
+++ b/src/PioneerUtils.jsm
@@ -164,7 +164,7 @@ export class PioneerUtils {
    *   An object from `config.branches`, chosen based on a `weight` key.
    */
   async chooseBranch() {
-    const hashKey = `${this.config.studyName}/${await this.getPioneerId()}`;
+    const hashKey = `${this.config.studyName}/${this.getPioneerId()}`;
     return sampling.chooseWeighted(this.config.branches, hashKey);
   }
 


### PR DESCRIPTION
This fixes https://github.com/mozilla/pioneer-study-online-news/pull/28#discussion_r149353108

The `getPioneerId` is not an async function and calling await causes the string interpolation to fail.