### PR TITLE
Pass startup info

### DIFF
--- a/src/PioneerUtils.ts
+++ b/src/PioneerUtils.ts
@@ -36,10 +36,7 @@ joseSetCrypto(crypto);
 
 export interface Config {
   /** Unique name of the study. */
-  studyName: string,
-
-  /** The ID of the study add-on */
-  addonId: string,
+  studyName: string;
 
   /** Optional. Which telemetry environment to send data to. */
   telemetryEnv?: "prod" | "stage";
@@ -48,7 +45,7 @@ export interface Config {
    * Branches of the experiment. If useful, you may store extra
    * data on each branch. It will be included when choosing a branch
    */
-  branches: Array<WeightedBranch>,
+  branches: Array<WeightedBranch>;
 
   /**
    * If this is set to true, PioneerUtils enables extra logging and
@@ -69,11 +66,13 @@ export class PioneerUtils {
   private config: Config;
   private encrypter: IEncrypter | null;
   private _logger: Logger | null;
+  private bootstrapData: BootstrapData;
 
-  constructor(config: Config) {
+  constructor(reason: number, data: BootstrapData, config: Config) {
     this.config = config;
     this.encrypter = null;
     this._logger = null;
+    this.bootstrapData = data;
   }
 
   /**
@@ -213,11 +212,11 @@ export class PioneerUtils {
    * Uninstalls the study addon.
    */
   async uninstall(): Promise<void> {
-    const addon = await AddonManager.getAddonByID(this.config.addonId);
+    const addon = await AddonManager.getAddonByID(this.bootstrapData.id);
     if (addon) {
       addon.uninstall();
     } else {
-      throw new Error(`Could not find addon with ID: ${this.config.addonId}`);
+      throw new Error(`Could not find addon with ID: ${this.bootstrapData.id}`);
     }
   }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -106,3 +106,41 @@ declare interface Logger {
   debug(message: string, params?: LogParameters): void;
   trace(message: string, params?: LogParameters): void;
 }
+
+declare interface nsIFile { }
+
+declare interface nsIURI { }
+
+declare interface BootstrapData {
+  /** The ID of the add-on being bootstrapped. */
+  id: string;
+
+  /** The version of the add-on being bootstrapped. */
+  version: string;
+
+  /**
+   * The installation location of the add-on being bootstrapped. This
+   * may be a directory or an XPI file depending on whether the add-on
+   * is installed unpacked or not.
+   */
+  installPath: nsIFile;
+
+  /**
+   * A URI pointing at the root of the add-ons files, this may be a
+   * jar: or file: URI depending on whether the add-on is installed
+   * unpacked or not.
+   */
+  resourceURI: nsIURI;
+
+  /**
+   * The previously installed version, if the reason is ADDON_UPGRADE
+   * or ADDON_DOWNGRADE, and the method is install or startup.
+   */
+  oldVersion?: string;
+
+  /**
+   * The version to be installed, if the reason is ADDON_UPGRADE or
+   * ADDON_DOWNGRADE, and the method is shutdown or uninstall.
+   */
+  newVersion?: string;
+}


### PR DESCRIPTION
Depends on #24. First commit here  is 9211b97. Typescript made it easy to be confident that I caught all the uses of `Config.addonId`