### PR TITLE
Update locked version of marked package to 0.3.9.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,7 +1708,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.9",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -1914,9 +1914,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "memory-fs": {
@@ -4586,7 +4586,7 @@
         "handlebars": "4.0.11",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.6",
+        "marked": "0.3.9",
         "minimatch": "3.0.4",
         "progress": "2.0.0",
         "shelljs": "0.7.8",


### PR DESCRIPTION
This picks up fixes for two medium severity security issues:

- CVE-2017-1000427
- CVE-2017-17461