### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # pioneer-utils
 
+:warning: This repository is deprecated.
+Please use <https://github.com/mozilla/shield-studies-addon-utils> instead.
+
+<old-readme>
+
+## Old readme
+
 Write add-ons for use with Pioneer more easily.
 
-## Get the utils
+### Get the utils
 
 * [source code](https://github.com/mozilla/pioneer-utils)
 * [npm package](https://www.npmjs.com/package/pioneer-utils)
+
+</old-readme>


### PR DESCRIPTION
With https://github.com/mozilla/shield-studies-addon-utils/pull/263, all new Pioneer studies should use https://github.com/mozilla/shield-studies-addon-utils instead of the utils in this repo. 

Fixes #25 (Request to merge / unfork: Shield-Studies-Addon-Utils)
Fixes #13 (Unit tests)
Fixes #7 (Set up CI)
Fixes #40 (Async/await for endStudy and submitEventPing)
Fixes #41 (Add EVENTS.INSTALLED)

Remaining issues should be re-created in https://github.com/mozilla/shield-studies-addon-utils and then closed here, or the repo should be archived / set as read-only. 